### PR TITLE
modif minimale parce que oapi-fr n'existe plus

### DIFF
--- a/bin/cadastre-housenumber/cadastre_fr/overpass.py
+++ b/bin/cadastre-housenumber/cadastre_fr/overpass.py
@@ -26,7 +26,7 @@ from .tools    import open_cached
 def open_osm_overpass(requete, cache_filename, metropole=False):
     if metropole:
         # oapi-fr.openstreetmap.fr n'a que la métropole, pas l'outre mer
-        overvass_server = "http://api.openstreetmap.fr/oapi/interpreter?"
+        overvass_server = "http://overpass-api.de/api/interpreter?"
     else:
         overvass_server = "http://overpass-api.de/api/interpreter?"
     url = overvass_server + urllib.urlencode({'data':requete})


### PR DESCRIPTION
modif minimale parce que oapi-fr n'existe plus
modif deja présente sur le serveur et fait dans git pour rétablir la synchro